### PR TITLE
feat(args): check `version` subcommand for version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 If you deal with command-line tools often, it might take some time to figure out how to get help or check the version of a particular command (especially when shell completions are not available). In that case, you might try the most-known flags such as `-h` and `-v` but unfortunately not all the command-line tools follow these conventions (either due to conflicts with other flags or they just use another form). Instead of _brute-forcing_ manually into getting help, you can run `halp <command>` and it will check the following arguments for you:
 
 - for **help**: `-h`, `--help`, `help`, `-H`
-- for **version info**: `-v`, `-V`, `--version`
+- for **version info**: `-v`, `-V`, `--version`, `version`
 
 If one of these arguments succeeds (with exit code 0), it prints the output and exits. This way, you can get informed about the version and help in one single command. You can also customize this list with a configuration file or provide a list of arguments via command-line arguments.
 

--- a/src/helper/args/common.rs
+++ b/src/helper/args/common.rs
@@ -40,6 +40,7 @@ generate_argument!(
     Version => "-v",
     CapitalVersion => "-V",
     LongVersion => "--version",
+    SubcommandVersion => "version",
 );
 
 generate_argument!(


### PR DESCRIPTION
<!--- Thank you for contributing to halp! 🐙 -->

## Description

This PR adds `version` subcommand to the list of arguments to check for version info.

## Motivation and Context

e.g. `zig` binary doesn't have a flag for getting the
version information. It requires to run `zig version`.

## How Has This Been Tested?

\-

## Screenshots / Logs (if applicable)

\-

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
