### PR TITLE
Add starting and ending separators for check_args success output

### DIFF
--- a/src/helper/args/mod.rs
+++ b/src/helper/args/mod.rs
@@ -47,7 +47,9 @@ fn check_args<'a, ArgsIter: Iterator<Item = &'a str>, Output: Write>(
                 "success".cyan().bold(),
                 arg.white().italic()
             )?;
+            println!("---");
             output.write_all(&cmd_out.stdout)?;
+            println!("---");
             break;
         } else {
             writeln!(


### PR DESCRIPTION
<!--- Thank you for contributing to halp! 🐙 -->

## Description

This PR adds starting and ending separators to the CLI tool's output when it finds matching arguments. 

<!--- Describe your changes in detail -->

## Motivation and Context

This issue: #4. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested by running `cargo run` for a few command-line tools: `nvim`, `bat`, `zoxide`, `whoami`.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

![halp-test-1](https://user-images.githubusercontent.com/4386534/232691252-632e7a4b-7c93-4578-be9e-adcdb9aa9789.png)

![halp-test-2](https://user-images.githubusercontent.com/4386534/232691285-f93be597-3cbf-495e-aef4-5cfb42b5a6e0.png)


## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
