### PR TITLE
Suport `cheat.sh` custom URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,11 +236,10 @@ halp [OPTIONS] plz <CMD>
 ```
 Options:
   -m, --man-cmd <MAN_CMD>   Sets the manual page command to run [default: man]
-      --cheat-sh-url <URL>  Cheat.sh URL [env: CHEAT_SH_URL=]
+      --cheat-sh-url <URL>  Use a custom URL for cheat.sh [env: CHEAT_SH_URL=]
   -p, --pager <PAGER>       Sets the pager to use [default: "less -R"]
       --no-pager            Disables the pager
   -h, --help                Print help
-
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -235,9 +235,12 @@ halp [OPTIONS] plz <CMD>
 
 ```
 Options:
-  -m, --man-cmd <MAN_CMD>  Sets the manual page command to run [default: man]
-  -p, --pager <PAGER>      Sets the pager to use [default: "less -R"]
-      --no-pager           Disables the pager
+  -m, --man-cmd <MAN_CMD>   Sets the manual page command to run [default: man]
+      --cheat-sh-url <URL>  Cheat.sh URL [env: CHEAT_SH_URL=]
+  -p, --pager <PAGER>       Sets the pager to use [default: "less -R"]
+      --no-pager            Disables the pager
+  -h, --help                Print help
+
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -313,6 +313,12 @@ To disable the pager:
 halp plz --no-pager bat vim
 ```
 
+##### Custom cheat.sh host URL
+
+```sh
+halp plz --cheat-sh-url https://cht.sh vim
+```
+
 ## Configuration
 
 `halp` can be configured with a configuration file that uses the [TOML](https://en.wikipedia.org/wiki/INI_file) format. It can be specified via `--config` or `HALP_CONFIG` environment variable. It can also be placed in one of the following global locations:

--- a/config/halp.toml
+++ b/config/halp.toml
@@ -10,3 +10,5 @@ check = [ [ "-v", "-V", "--version" ], [ "-h", "--help", "help", "-H" ] ]
 man_command = "man"
 # pager to use for command outputs
 pager_command = "less -R"
+# Cheat.sh URL
+cheat_sh_url = "https://cheat.sh"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,10 +53,10 @@ pub enum CliCommands {
         cheat_sh_url: Option<String>,
         /// Sets the pager to use.
         #[arg(
-        short,
-        long,
-        default_value = "less -R",
-        default_value_if("no_pager", ArgPredicate::IsPresent, None)
+            short,
+            long,
+            default_value = "less -R",
+            default_value_if("no_pager", ArgPredicate::IsPresent, None)
         )]
         pager: Option<String>,
         /// Disables the pager.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,12 +5,12 @@ use std::path::PathBuf;
 /// Command-line arguments.
 #[derive(Debug, Default, Parser)]
 #[command(
-    version,
-    author,
-    about,
-    subcommand_negates_reqs = true,
-    disable_help_subcommand = true,
-    override_usage = format!("
+version,
+author,
+about,
+subcommand_negates_reqs = true,
+disable_help_subcommand = true,
+override_usage = format!("
   {bin} [OPTIONS] <CMD>
   {bin} [OPTIONS] <COMMAND> <CMD>", bin = env!("CARGO_PKG_NAME"))
 )]
@@ -48,12 +48,15 @@ pub enum CliCommands {
         /// Sets the manual page command to run.
         #[arg(short, long, default_value = "man")]
         man_cmd: String,
+        /// Cheat.sh URL.
+        #[arg(long, env = "CHEAT_SH_URL", value_name = "URL")]
+        cheat_sh_url: Option<String>,
         /// Sets the pager to use.
         #[arg(
-            short,
-            long,
-            default_value = "less -R",
-            default_value_if("no_pager", ArgPredicate::IsPresent, None)
+        short,
+        long,
+        default_value = "less -R",
+        default_value_if("no_pager", ArgPredicate::IsPresent, None)
         )]
         pager: Option<String>,
         /// Disables the pager.
@@ -67,6 +70,7 @@ impl Default for CliCommands {
         CliCommands::Plz {
             cmd: String::new(),
             man_cmd: String::from("man"),
+            cheat_sh_url: None,
             pager: Some(String::from("less")),
             no_pager: false,
         }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -48,7 +48,7 @@ pub enum CliCommands {
         /// Sets the manual page command to run.
         #[arg(short, long, default_value = "man")]
         man_cmd: String,
-        /// Cheat.sh URL.
+        /// Use a custom URL for cheat.sh.
         #[arg(long, env = "CHEAT_SH_URL", value_name = "URL")]
         cheat_sh_url: Option<String>,
         /// Sets the pager to use.

--- a/src/config.rs
+++ b/src/config.rs
@@ -73,7 +73,11 @@ impl Config {
             }
         }
         if let Some(cheat_sh_url_conf) = &self.cheat_sh_url {
-            if let Some(CliCommands::Plz { ref mut cheat_sh_url, .. }) = cli_args.subcommand {
+            if let Some(CliCommands::Plz {
+                ref mut cheat_sh_url,
+                ..
+            }) = cli_args.subcommand
+            {
                 if cheat_sh_url.is_none() {
                     *cheat_sh_url = Some(cheat_sh_url_conf.clone());
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,8 @@ pub struct Config {
     pub man_command: Option<String>,
     /// Pager to use for command outputs.
     pub pager_command: Option<String>,
+    /// Cheat.sh URL.
+    pub cheat_sh_url: Option<String>,
 }
 
 impl Config {
@@ -68,6 +70,13 @@ impl Config {
         if let Some(pager_command) = &self.pager_command {
             if let Some(CliCommands::Plz { ref mut pager, .. }) = cli_args.subcommand {
                 *pager = Some(pager_command.clone());
+            }
+        }
+        if let Some(cheat_sh_url_conf) = &self.cheat_sh_url {
+            if let Some(CliCommands::Plz { ref mut cheat_sh_url, .. }) = cli_args.subcommand {
+                if cheat_sh_url.is_none() {
+                    *cheat_sh_url = Some(cheat_sh_url_conf.clone());
+                }
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ pub struct Config {
     pub man_command: Option<String>,
     /// Pager to use for command outputs.
     pub pager_command: Option<String>,
-    /// Cheat.sh URL.
+    /// Use a custom URL for cheat.sh.
     pub cheat_sh_url: Option<String>,
 }
 

--- a/src/helper/docs/cheat.rs
+++ b/src/helper/docs/cheat.rs
@@ -3,8 +3,8 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 use ureq::AgentBuilder;
 
-/// Cheat sheet provider URL.
-const CHEAT_SHEET_PROVIDER: &str = "https://cheat.sh";
+/// Default cheat sheet provider URL.
+const DEFAULT_CHEAT_SHEET_PROVIDER: &str = "https://cheat.sh";
 
 /// User agent for the cheat sheet provider.
 ///
@@ -14,14 +14,16 @@ const CHEAT_SHEET_USER_AGENT: &str = "fetch";
 /// Shows the cheat sheet for the given command.
 pub fn show_cheat_sheet<Output: Write>(
     cmd: &str,
+    url: &Option<String>,
     pager: &Option<String>,
     output: &mut Output,
 ) -> Result<()> {
     let client = AgentBuilder::new()
         .user_agent(CHEAT_SHEET_USER_AGENT)
         .build();
+    let default_url = DEFAULT_CHEAT_SHEET_PROVIDER.to_string();
     let cheat_sheet = client
-        .get(&format!("{}/{}", CHEAT_SHEET_PROVIDER, cmd))
+        .get(&format!("{}/{}", url.clone().unwrap_or(default_url), cmd))
         .call()
         .map_err(|e| Error::from(Box::new(e)))?
         .into_string()?;
@@ -58,7 +60,7 @@ mod tests {
     #[test]
     fn test_fetch_cheat_sheet() -> Result<()> {
         let mut output = Vec::new();
-        show_cheat_sheet("ls", &None, &mut output)?;
+        show_cheat_sheet("ls", None, &None, &mut output)?;
         let output = String::from_utf8_lossy(&output);
         assert!(output.contains(
             "# To display all files, along with the size (with unit suffixes) and timestamp:"

--- a/src/helper/docs/cheat.rs
+++ b/src/helper/docs/cheat.rs
@@ -60,7 +60,7 @@ mod tests {
     #[test]
     fn test_fetch_cheat_sheet() -> Result<()> {
         let mut output = Vec::new();
-        show_cheat_sheet("ls", None, &None, &mut output)?;
+        show_cheat_sheet("ls", &None, &None, &mut output)?;
         let output = String::from_utf8_lossy(&output);
         assert!(output.contains(
             "# To display all files, along with the size (with unit suffixes) and timestamp:"

--- a/src/helper/docs/mod.rs
+++ b/src/helper/docs/mod.rs
@@ -16,6 +16,7 @@ use std::io::Write;
 pub fn get_docs_help<Output: Write>(
     cmd: &str,
     man_cmd: &str,
+    cheat_sh_url: Option<String>,
     pager: Option<String>,
     output: &mut Output,
 ) -> Result<()> {
@@ -28,7 +29,7 @@ pub fn get_docs_help<Output: Write>(
             .interact_on_opt(&Term::stderr())?;
         match selection {
             Some(0) => show_man_page(man_cmd, cmd)?,
-            Some(1) => show_cheat_sheet(cmd, &pager, output)?,
+            Some(1) => show_cheat_sheet(cmd, &cheat_sh_url, &pager, output)?,
             _ => return Ok(()),
         };
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,11 +40,12 @@ pub fn run<Output: Write>(mut cli_args: CliArgs, output: &mut Output) -> Result<
     } else if let Some(CliCommands::Plz {
         ref cmd,
         ref man_cmd,
+        cheat_sh_url,
         pager,
         ..
     }) = cli_args.subcommand
     {
-        get_docs_help(cmd, man_cmd, pager, output)?;
+        get_docs_help(cmd, man_cmd, cheat_sh_url, pager, output)?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Description
Make the [cheat.sh](https://cheat.sh) configurable by  the configuration file and by the command line arguments (`--cheat-sh-url`)

## Motivation and Context
- Closes: #57 

## How Has This Been Tested?
- I ran the program with the help argument(`cargo r -- plz --help`) and it gives  me the expected output
- I ran the tests and they **partially** passed

## Screenshots / Logs (if applicable)
![image](https://github.com/orhun/halp/assets/44965145/6fc50771-a3bd-4cb8-9592-42f0eed70ce9)

## Types of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

> **Note**: Some  of exists tests failed when I try to run them with the standard output (`cargo t --lib`), but they passed when I try to pipe the output into smoothing else , like `xclip` (`cargo test --lib | xclip -selection clipboard`)
[![asciicast](https://asciinema.org/a/593040.svg)](https://asciinema.org/a/593040)