### PR TITLE
chore(docker): remove the duplicated `.gitignore` entry

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,4 +18,3 @@ _config.yml
 codecov.yml
 .editorconfig
 .codespellignore
-.gitignore


### PR DESCRIPTION
My smart IDE noticed that we've duplicated the `.gitignore` entry in the same `.dockerignore` file. so  I removed the repeated entry

> AKA free PR
