### PR TITLE
fix(cli): fix the check option 

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -70,6 +70,9 @@ impl CliArgs {
     pub fn update_config(&self, config: &mut Config) {
         config.check_help = !self.no_help;
         config.check_version = !self.no_version;
+        if let Some(ref args) = self.check_args {
+            config.check_args = Some(args.iter().map(|s| vec![s.to_string()]).collect());
+        }
         if let Some(CliCommands::Plz {
             ref man_cmd,
             ref cheat_sh_url,


### PR DESCRIPTION
<!--- Thank you for contributing to halp! 🐙 -->

## Description
Add the missing code to override the check args in the config instance with the `--check` CLI option

## Motivation and Context
- Fix the issue that's introduced in #62 

## How Has This Been Tested?
- I trayed to pass `--check="-h"` and it worked as expected
- I trayed to pass ` --check='-h' --check='-V'` and it worked as expected also

## Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

> This's an alternative to #79 