### PR TITLE
feat(command): add timeout for terminating process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "dialoguer",
  "dirs",
  "pretty_assertions",
+ "process_control",
  "serde",
  "thiserror",
  "toml",
@@ -412,6 +413,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process_control"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d18334c4a4b2770ee894e63cf466d5a9ea449cf29e321101b0b135a747afb6f"
+dependencies = [
+ "libc",
+ "signal-hook",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -541,6 +553,25 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ colored = "2.1.0"
 console = "0.15.8"
 dialoguer = { version = "0.11.0", default-features = false }
 dirs = "5.0.1"
+process_control = "4.1.0"
 serde = { version = "1.0.202", features = ["derive"] }
 thiserror = "1.0.61"
 toml = "0.8.13"

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Options:
       --no-version     Disable checking the version information
       --no-help        Disable checking the help information
   -c, --config <PATH>  Sets the configuration file [env: HALP_CONFIG=]
+  -t, --timeout <S>    Sets the timeout for the command [default: 5]
   -v, --verbose        Enables verbose logging
   -h, --help           Print help
   -V, --version        Print version

--- a/config/halp.toml
+++ b/config/halp.toml
@@ -5,10 +5,12 @@ check_version = true
 # check the help flag
 check_help = true
 # arguments to check
-check = [ [ "-v", "-V", "--version" ], [ "-h", "--help", "help", "-H" ] ]
+check = [["-v", "-V", "--version"], ["-h", "--help", "help", "-H"]]
 # command to run for manual pages
 man_command = "man"
 # pager to use for command outputs
 pager_command = "less -R"
 # Cheat.sh URL
 cheat_sh_url = "https://cheat.sh"
+# Timeout for the commands
+timeout = 5

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,8 +31,8 @@ pub struct CliArgs {
     #[arg(short, long, env = "HALP_CONFIG", value_name = "PATH")]
     pub config: Option<PathBuf>,
     /// Sets the timeout for the command.
-    #[arg(short, long, value_name = "S", default_value_t = 5)]
-    pub timeout: u64,
+    #[arg(short, long, value_name = "S")]
+    pub timeout: Option<u64>,
     /// Enables verbose logging.
     #[arg(short, long)]
     pub verbose: bool,
@@ -82,6 +82,9 @@ impl CliArgs {
         if let Some(ref args) = self.check_args {
             config.check_args = Some(args.iter().map(|s| vec![s.to_string()]).collect());
         }
+        if self.timeout.is_some() {
+            config.timeout = self.timeout;
+        }
         if let Some(CliCommands::Plz {
             ref man_cmd,
             ref cheat_sh_url,
@@ -122,7 +125,7 @@ mod tests {
     }
 
     #[test]
-    fn test_update_conf() {
+    fn test_update_config() {
         let mut config = Config::default();
         let args = CliArgs {
             subcommand: Some(CliCommands::Plz {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,6 +30,9 @@ pub struct CliArgs {
     /// Sets the configuration file.
     #[arg(short, long, env = "HALP_CONFIG", value_name = "PATH")]
     pub config: Option<PathBuf>,
+    /// Sets the timeout for the command.
+    #[arg(short, long, value_name = "S", default_value_t = 5)]
+    pub timeout: u64,
     /// Enables verbose logging.
     #[arg(short, long)]
     pub verbose: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,8 @@ pub struct Config {
     pub eg_url: Option<String>,
     /// Use a custom URL for cheatsheets provider.
     pub cheatsheets_url: Option<String>,
+    /// Timeout for running the commands.
+    pub timeout: Option<u64>,
 }
 
 impl Default for Config {
@@ -53,6 +55,7 @@ impl Default for Config {
             cheat_sh_url: Some(DEFAULT_CHEAT_SHEET_PROVIDER.to_string()),
             eg_url: Some(DEFAULT_EG_PAGES_PROVIDER.to_string()),
             cheatsheets_url: Some(DEFAULT_CHEATSHEETS_PROVIDER.to_string()),
+            timeout: Some(5),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,7 +25,7 @@ pub enum Error {
     #[error("Dialogue error: `{0}`")]
     DialogueError(#[from] dialoguer::Error),
     /// Error that might occur when the command times out.
-    #[error("Command timed out after {0} seconds")]
+    #[error("Command timed out after {0} seconds x_x")]
     TimeoutError(u64),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,9 @@ pub enum Error {
     /// Error that might occur during showing dialogues.
     #[error("Dialogue error: `{0}`")]
     DialogueError(#[from] dialoguer::Error),
+    /// Error that might occur when the command times out.
+    #[error("Command timed out after {0} seconds")]
+    TimeoutError(u64),
 }
 
 /// Type alias for the standard [`Result`] type.

--- a/src/helper/args/mod.rs
+++ b/src/helper/args/mod.rs
@@ -98,7 +98,6 @@ pub fn get_args_help<Output: Write>(
     cmd: &str,
     config: &Config,
     verbose: bool,
-    timeout: u64,
     output: &mut Output,
 ) -> Result<()> {
     if cmd.trim().is_empty() {
@@ -119,7 +118,9 @@ pub fn get_args_help<Output: Write>(
                 cmd,
                 arg_variants.iter().map(|v| v.as_str()),
                 verbose,
-                timeout,
+                config
+                    .timeout
+                    .unwrap_or_else(|| Config::default().timeout.unwrap_or_default()),
                 output,
             )?;
         }
@@ -228,7 +229,7 @@ Options:
     fn test_get_default_help() -> Result<()> {
         let config = Config::default();
         let mut output = Vec::new();
-        get_args_help(&get_test_bin(), &config, false, 5, &mut output)?;
+        get_args_help(&get_test_bin(), &config, false, &mut output)?;
         println!("{}", String::from_utf8_lossy(&output));
         assert_eq!(
             r"(°ロ°)  checking 'test -v'
@@ -263,7 +264,7 @@ Options:
             ..Default::default()
         };
         let mut output = Vec::new();
-        get_args_help(&get_test_bin(), &config, false, 5, &mut output)?;
+        get_args_help(&get_test_bin(), &config, false, &mut output)?;
         println!("{}", String::from_utf8_lossy(&output));
         assert_eq!(
             r"(°ロ°)  checking 'test -x'
@@ -290,7 +291,7 @@ halp 0.1.0
             ..Default::default()
         };
         let mut output = Vec::new();
-        get_args_help("", &config, false, 5, &mut output)?;
+        get_args_help("", &config, false, &mut output)?;
         assert!(String::from_utf8_lossy(&output).is_empty());
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub fn run<Output: Write>(cli_args: CliArgs, output: &mut Output) -> Result<()> 
     };
     cli_args.update_config(&mut config);
     if let Some(ref cmd) = cli_args.cmd {
-        get_args_help(cmd, &config, cli_args.verbose, output)?;
+        get_args_help(cmd, &config, cli_args.verbose, cli_args.timeout, output)?;
     } else if let Some(CliCommands::Plz { ref cmd, .. }) = cli_args.subcommand {
         get_docs_help(cmd, &config, output)?;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub fn run<Output: Write>(cli_args: CliArgs, output: &mut Output) -> Result<()> 
     };
     cli_args.update_config(&mut config);
     if let Some(ref cmd) = cli_args.cmd {
-        get_args_help(cmd, &config, cli_args.verbose, cli_args.timeout, output)?;
+        get_args_help(cmd, &config, cli_args.verbose, output)?;
     } else if let Some(CliCommands::Plz { ref cmd, .. }) = cli_args.subcommand {
         get_docs_help(cmd, &config, output)?;
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10,7 +10,7 @@ const BIN: &str = env!("CARGO_BIN_EXE_halp-test");
 fn get_argument_help() -> Result<()> {
     let args = CliArgs {
         cmd: Some(BIN.to_string()),
-        timeout: 10,
+        timeout: Some(10),
         config: Some(
             PathBuf::from(env!("CARGO_MANIFEST_DIR"))
                 .join("config")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -10,6 +10,7 @@ const BIN: &str = env!("CARGO_BIN_EXE_halp-test");
 fn get_argument_help() -> Result<()> {
     let args = CliArgs {
         cmd: Some(BIN.to_string()),
+        timeout: 10,
         config: Some(
             PathBuf::from(env!("CARGO_MANIFEST_DIR"))
                 .join("config")


### PR DESCRIPTION
## Description

This PR adds a new command line argument (`--timeout`) for terminating the process if it is running more than 5 seconds.

## Motivation and Context

closes #213

## How Has This Been Tested?

Locally

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
