### PR TITLE
refactor: replace format! with concat! for string literals

### DIFF
--- a/src/bin/mangen.rs
+++ b/src/bin/mangen.rs
@@ -16,7 +16,7 @@ use std::path::PathBuf;
 /// See <https://doc.rust-lang.org/cargo/reference/environment-variables.html>
 fn main() -> Result<()> {
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR is not set");
-    let out_path = PathBuf::from(out_dir).join(format!("{}.1", env!("CARGO_PKG_NAME")));
+    let out_path = PathBuf::from(out_dir).join(concat!(env!("CARGO_PKG_NAME"), ".1"));
     let app = CliArgs::command();
     let man = Man::new(app);
     let mut buffer = Vec::<u8>::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,7 +82,7 @@ impl Config {
     #[inline(always)]
     fn get_default_locations() -> Option<Vec<PathBuf>> {
         if let Some(config_dir) = dirs::config_dir() {
-            let file_name = format!("{}.toml", env!("CARGO_PKG_NAME"));
+            let file_name = concat!(env!("CARGO_PKG_NAME"), ".toml");
             return Some(vec![
                 config_dir.join(&file_name),
                 config_dir.join(env!("CARGO_PKG_NAME")).join(&file_name), // XDG style
@@ -132,7 +132,7 @@ mod tests {
     fn test_parse_config() -> Result<()> {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("config")
-            .join(format!("{}.toml", env!("CARGO_PKG_NAME")));
+            .join(concat!(env!("CARGO_PKG_NAME"), ".toml"));
         if let Some(global_path) = Config::get_default_location() {
             path = global_path;
         }

--- a/src/helper/args/mod.rs
+++ b/src/helper/args/mod.rs
@@ -140,7 +140,7 @@ mod tests {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("target")
             .join("debug")
-            .join(format!("{}-test", env!("CARGO_PKG_NAME")))
+            .join(concat!(env!("CARGO_PKG_NAME"), "-test"))
             .to_string_lossy()
             .to_string()
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14,7 +14,7 @@ fn get_argument_help() -> Result<()> {
         config: Some(
             PathBuf::from(env!("CARGO_MANIFEST_DIR"))
                 .join("config")
-                .join(format!("{}.toml", env!("CARGO_PKG_NAME"))),
+                .join(concat!(env!("CARGO_PKG_NAME"), ".toml")),
         ),
         ..Default::default()
     };


### PR DESCRIPTION
<!--- Thank you for contributing to halp! 🐙 -->

## Description

- Replace `format!` with `concat!` for string literals

## Motivation and Context

- Although `format!` macro is very powerful, it introduces overhead of memory allocation on the heap compared to `&str`. Therefore, when `format!` macro is unnecessary, we should avoid using it.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots / Logs (if applicable)

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [x] Refactor (refactoring production code)
- [ ] Other <!--- (provide information) -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
