### PR TITLE
fix(ureq): migrate HTTP client to ureq v3 API (fixes #356, cannot build from source)

### DIFF
--- a/src/helper/docs/cheat_sh.rs
+++ b/src/helper/docs/cheat_sh.rs
@@ -1,6 +1,6 @@
 use crate::error::{Error, Result};
 use crate::helper::docs::HelpProvider;
-use ureq::{AgentBuilder, Request};
+use ureq::Agent;
 
 /// Default cheat sheet provider URL.
 pub const DEFAULT_CHEAT_SHEET_PROVIDER: &str = "https://cheat.sh";
@@ -18,11 +18,16 @@ impl HelpProvider for CheatDotSh {
         DEFAULT_CHEAT_SHEET_PROVIDER
     }
 
-    fn build_request(&self, cmd: &str, url: &str) -> Request {
-        AgentBuilder::new()
+    fn build_request(
+        &self,
+        cmd: &str,
+        url: &str,
+    ) -> ureq::RequestBuilder<ureq::typestate::WithoutBody> {
+        let agent: Agent = Agent::config_builder()
             .user_agent(CHEAT_SHEET_USER_AGENT)
             .build()
-            .get(&format!("{}/{}", url, cmd))
+            .into();
+        agent.get(&format!("{}/{}", url, cmd))
     }
 
     fn fetch(&self, cmd: &str, custom_url: &Option<String>) -> Result<String> {

--- a/src/helper/docs/cheatsheets.rs
+++ b/src/helper/docs/cheatsheets.rs
@@ -1,5 +1,5 @@
 use crate::helper::docs::HelpProvider;
-use ureq::{AgentBuilder, Request};
+use ureq::Agent;
 
 /// The default cheatsheets provider URL.
 pub const DEFAULT_CHEATSHEETS_PROVIDER: &str =
@@ -13,8 +13,13 @@ impl HelpProvider for Cheatsheets {
         DEFAULT_CHEATSHEETS_PROVIDER
     }
 
-    fn build_request(&self, cmd: &str, url: &str) -> Request {
-        AgentBuilder::new().build().get(&format!("{}/{}", url, cmd))
+    fn build_request(
+        &self,
+        cmd: &str,
+        url: &str,
+    ) -> ureq::RequestBuilder<ureq::typestate::WithoutBody> {
+        let agent: Agent = Agent::config_builder().build().into();
+        agent.get(&format!("{}/{}", url, cmd))
     }
 }
 

--- a/src/helper/docs/eg.rs
+++ b/src/helper/docs/eg.rs
@@ -1,5 +1,5 @@
 use crate::helper::docs::HelpProvider;
-use ureq::{AgentBuilder, Request};
+use ureq::Agent;
 
 /// EG page provider URL.
 pub const DEFAULT_EG_PAGES_PROVIDER: &str =
@@ -13,10 +13,13 @@ impl HelpProvider for Eg {
         DEFAULT_EG_PAGES_PROVIDER
     }
 
-    fn build_request(&self, cmd: &str, url: &str) -> Request {
-        AgentBuilder::new()
-            .build()
-            .get(&format!("{}/{}.md", url, cmd))
+    fn build_request(
+        &self,
+        cmd: &str,
+        url: &str,
+    ) -> ureq::RequestBuilder<ureq::typestate::WithoutBody> {
+        let agent: Agent = Agent::config_builder().build().into();
+        agent.get(&format!("{}/{}.md", url, cmd))
     }
 }
 

--- a/src/helper/docs/mod.rs
+++ b/src/helper/docs/mod.rs
@@ -19,8 +19,6 @@ use dialoguer::theme::ColorfulTheme;
 use dialoguer::Select;
 use std::io::Write;
 use std::process::{Command, Stdio};
-use ureq::Request;
-
 /// The `HelpProvider` trait defines essential methods for fetching help content related to commands from a provider.
 ///
 /// Each provider that implements this trait should provide a default URL used to retrieve the command help content.
@@ -55,13 +53,17 @@ pub trait HelpProvider {
     /// - `url`: The root URL.
     ///
     /// # Returns
-    /// This method returns a new `Request` instance configured with the `GET` method and the formatted URL.
-    fn build_request(&self, cmd: &str, url: &str) -> Request;
+    /// This method returns a new `RequestBuilder` configured with the `GET` method and the formatted URL.
+    fn build_request(
+        &self,
+        cmd: &str,
+        url: &str,
+    ) -> ureq::RequestBuilder<ureq::typestate::WithoutBody>;
 
     /// Handle the request error.
     /// aka return a custom message if the error means that **provider** doesn't have a page for the command.
     fn handle_error(&self, e: ureq::Error) -> Error {
-        if e.kind() == ureq::ErrorKind::HTTP {
+        if matches!(e, ureq::Error::StatusCode(_)) {
             Error::ProviderError(
                 "Unknown topic, This topic/command might has no page in this provider yet."
                     .to_string(),
@@ -90,7 +92,10 @@ pub trait HelpProvider {
         let response = response.map_err(|e| self.handle_error(e));
 
         match response {
-            Ok(response) => Ok(response.into_string()?),
+            Ok(mut response) => response
+                .body_mut()
+                .read_to_string()
+                .map_err(|e| Error::from(Box::new(e))),
             Err(e) => Err(e),
         }
     }


### PR DESCRIPTION
Fixes #356 (cannot build from source).

**Problem:** `Cargo.toml` pins `ureq = "3.3.0"`, but the HTTP code was written for the ureq v2 API. ureq v3 is a breaking rewrite, so the crate fails to compile (9 errors): `AgentBuilder` removed, `ureq::Request` now private, `ErrorKind` removed, `into_string()` changed.

**Fix:** migrate the four `src/helper/docs/*.rs` HTTP call sites to the ureq v3 API — `Agent::config_builder()...build().into()`, `build_request` returns `ureq::RequestBuilder<..>`, error detection via `matches!(e, ureq::Error::StatusCode(_))`, body read via `response.body_mut().read_to_string()`.

**Verified:** `cargo build` now finishes clean (was 9 errors); the 3 network tests that exercise the changed code pass.

---

Came across halp and saw #356 (cannot build from source), so I migrated the HTTP client to the current ureq API to get it building again. No strings. I do this kind of work (Choreless — we fix and ship code for small teams), so if you ever want a hand, I'm around. — Charles
