### PR TITLE
fix(args): prefer --help/--version before short flags by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 
 If you deal with command-line tools often, it might take some time to figure out how to get help or check the version of a particular command (especially when shell completions are not available). In that case, you might try the most-known flags such as `-h` and `-v` but unfortunately not all the command-line tools follow these conventions (either due to conflicts with other flags or they just use another form). Instead of _brute-forcing_ manually into getting help, you can run `halp <command>` and it will check the following arguments for you:
 
-- for **help**: `-h`, `--help`, `help`, `-H`
-- for **version info**: `-v`, `-V`, `--version`, `version`
+- for **help**: `--help`, `-h`, `help`, `-H`
+- for **version info**: `--version`, `-v`, `version`, `-V`
 
 If one of these arguments succeeds (with exit code 0), it prints the output and exits. This way, you can get informed about the version and help in one single command. You can also customize this list with a configuration file or provide a list of arguments via command-line arguments.
 

--- a/config/halp.toml
+++ b/config/halp.toml
@@ -5,7 +5,7 @@ check_version = true
 # check the help flag
 check_help = true
 # arguments to check
-check = [["-v", "-V", "--version"], ["-h", "--help", "help", "-H"]]
+check = [["--version", "-v", "version", "-V"], ["--help", "-h", "help", "-H"]]
 # command to run for manual pages
 man_command = "man"
 # pager to use for command outputs

--- a/src/config.rs
+++ b/src/config.rs
@@ -145,4 +145,26 @@ mod tests {
         );
         Ok(())
     }
+
+    #[test]
+    fn test_default_check_args_prefer_long_forms() {
+        let config = Config::default();
+        assert_eq!(
+            config.check_args,
+            Some(vec![
+                vec![
+                    "--version".to_string(),
+                    "-v".to_string(),
+                    "version".to_string(),
+                    "-V".to_string(),
+                ],
+                vec![
+                    "--help".to_string(),
+                    "-h".to_string(),
+                    "help".to_string(),
+                    "-H".to_string(),
+                ],
+            ])
+        );
+    }
 }

--- a/src/helper/args/common.rs
+++ b/src/helper/args/common.rs
@@ -37,16 +37,18 @@ macro_rules! generate_argument {
 
 generate_argument!(
     VersionArg,
-    Version => "-v",
-    CapitalVersion => "-V",
+    // Prefer long forms first: some tools (e.g. `ps`) use `-v`/`-h` for other meaning.
     LongVersion => "--version",
+    Version => "-v",
     SubcommandVersion => "version",
+    CapitalVersion => "-V",
 );
 
 generate_argument!(
     HelpArg,
-    Help => "-h",
+    // Prefer `--help` before `-h` for the same reason as VersionArg.
     LongHelp => "--help",
+    Help => "-h",
     SubcommandHelp => "help",
     CapitalHelp => "-H",
 );
@@ -68,6 +70,24 @@ mod tests {
         assert_eq!(
             vec!["one", "two", "three"],
             Test::variants()
+                .iter()
+                .map(|v| v.as_str())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_version_and_help_prefer_long_forms() {
+        assert_eq!(
+            vec!["--version", "-v", "version", "-V"],
+            VersionArg::variants()
+                .iter()
+                .map(|v| v.as_str())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            vec!["--help", "-h", "help", "-H"],
+            HelpArg::variants()
                 .iter()
                 .map(|v| v.as_str())
                 .collect::<Vec<_>>()

--- a/src/helper/args/mod.rs
+++ b/src/helper/args/mod.rs
@@ -157,10 +157,8 @@ mod tests {
         )?;
         println!("{}", String::from_utf8_lossy(&output));
         assert_eq!(
-            r"(°ロ°)  checking 'test -v'
-(×﹏×)      fail '-v' argument not found.
-(°ロ°)  checking 'test -V'
-\(^ヮ^)/ success '-V' argument found!
+            r"(°ロ°)  checking 'test --version'
+\(^ヮ^)/ success '--version' argument found!
 ---
 halp 0.1.0
 ---",
@@ -232,15 +230,13 @@ Options:
         get_args_help(&get_test_bin(), &config, false, &mut output)?;
         println!("{}", String::from_utf8_lossy(&output));
         assert_eq!(
-            r"(°ロ°)  checking 'test -v'
-(×﹏×)      fail '-v' argument not found.
-(°ロ°)  checking 'test -V'
-\(^ヮ^)/ success '-V' argument found!
+            r"(°ロ°)  checking 'test --version'
+\(^ヮ^)/ success '--version' argument found!
 ---
 halp 0.1.0
 ---
-(°ロ°)  checking 'test -h'
-\(^ヮ^)/ success '-h' argument found!
+(°ロ°)  checking 'test --help'
+\(^ヮ^)/ success '--help' argument found!
 ---
 Usage: test
 


### PR DESCRIPTION
<!--- Thank you for contributing to halp! 🐙 -->

## Description

Change the built-in default check order so long forms are tried first:

- version: `--version`, `-v`, `version`, `-V`
- help: `--help`, `-h`, `help`, `-H`

This matches the config suggested in the issue thread and updates the sample `config/halp.toml` + README accordingly.

## Motivation and Context

Fixes https://github.com/orhun/halp/issues/137

Some tools (e.g. `ps`) use `-h`/`-v` for meanings other than help/version, so preferring the long forms by default avoids false “success” on the wrong flag. Maintainer invited making this the internal default.

## How Has This Been Tested?

- `cargo test --lib prefer_long` / `default_check_args` — new unit tests for variant + `Config::default()` order
- `cargo fmt --all`
- Updated existing TTY-backed expectation strings in `helper::args` tests for the new success path (those tests need a real TTY/`script` environment; they fail in non-TTY sandboxes independently of this change)

## Screenshots / Logs (if applicable)

N/A

## Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [ ] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy). (pre-existing clippy warnings on unrelated lines)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. (TTY integration tests require a real terminal; unit tests for the new default order pass)


Made with [Cursor](https://cursor.com)