### PR TITLE
feat(docs): add --insecure to skip TLS certificate verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ Options:
       --cheat-sh-url <URL>  Use a custom URL for cheat.sh [env: CHEAT_SH_URL=]
   -p, --pager <PAGER>       Sets the pager to use
       --no-pager            Disables the pager
+      --insecure            Disables TLS certificate verification for HTTP requests
   -h, --help                Print help
 ```
 
@@ -320,6 +321,18 @@ halp plz --no-pager bat vim
 ```sh
 halp plz --cheat-sh-url https://cht.sh vim
 ```
+
+##### Skipping TLS certificate verification
+
+Behind a TLS-inspecting proxy the providers are reached through a certificate that is not in the
+system trust store, which fails with `invalid peer certificate: UnknownIssuer`. To skip
+verification:
+
+```sh
+halp plz --insecure vim
+```
+
+This disables certificate checking for the request, so only use it on networks you trust.
 
 ## Configuration
 

--- a/config/halp.toml
+++ b/config/halp.toml
@@ -14,3 +14,5 @@ pager_command = "less -R"
 cheat_sh_url = "https://cheat.sh"
 # Timeout for the commands
 timeout = 5
+# Disable TLS certificate verification for the help providers
+insecure = false

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -66,6 +66,9 @@ pub enum CliCommands {
         /// Disables the pager.
         #[arg(long)]
         no_pager: bool,
+        /// Disables TLS certificate verification for HTTP requests.
+        #[arg(long)]
+        insecure: bool,
     },
 }
 
@@ -91,6 +94,7 @@ impl CliArgs {
             ref eg_url,
             no_pager,
             ref pager,
+            insecure,
             ..
         }) = self.subcommand
         {
@@ -107,6 +111,9 @@ impl CliArgs {
                 config.pager_command = None;
             } else if let Some(pager) = pager {
                 config.pager_command = Some(pager.clone());
+            }
+            if insecure {
+                config.insecure = true;
             }
         }
     }
@@ -136,6 +143,7 @@ mod tests {
                 eg_url: None,
                 man_cmd: None,
                 no_pager: false,
+                insecure: false,
             }),
             ..Default::default()
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,9 @@ pub struct Config {
     pub cheatsheets_url: Option<String>,
     /// Timeout for running the commands.
     pub timeout: Option<u64>,
+    /// Disable TLS certificate verification for HTTP requests.
+    #[serde(default)]
+    pub insecure: bool,
 }
 
 impl Default for Config {
@@ -56,6 +59,7 @@ impl Default for Config {
             eg_url: Some(DEFAULT_EG_PAGES_PROVIDER.to_string()),
             cheatsheets_url: Some(DEFAULT_CHEATSHEETS_PROVIDER.to_string()),
             timeout: Some(5),
+            insecure: false,
         }
     }
 }

--- a/src/helper/docs/cheat_sh.rs
+++ b/src/helper/docs/cheat_sh.rs
@@ -1,5 +1,5 @@
 use crate::error::{Error, Result};
-use crate::helper::docs::HelpProvider;
+use crate::helper::docs::{apply_insecure, HelpProvider};
 use ureq::Agent;
 
 /// Default cheat sheet provider URL.
@@ -22,16 +22,19 @@ impl HelpProvider for CheatDotSh {
         &self,
         cmd: &str,
         url: &str,
+        insecure: bool,
     ) -> ureq::RequestBuilder<ureq::typestate::WithoutBody> {
-        let agent: Agent = Agent::config_builder()
-            .user_agent(CHEAT_SHEET_USER_AGENT)
-            .build()
-            .into();
+        let agent: Agent = apply_insecure(
+            Agent::config_builder().user_agent(CHEAT_SHEET_USER_AGENT),
+            insecure,
+        )
+        .build()
+        .into();
         agent.get(&format!("{}/{}", url, cmd))
     }
 
-    fn fetch(&self, cmd: &str, custom_url: &Option<String>) -> Result<String> {
-        let response = self._fetch(cmd, custom_url);
+    fn fetch(&self, cmd: &str, custom_url: &Option<String>, insecure: bool) -> Result<String> {
+        let response = self._fetch(cmd, custom_url, insecure);
         if let Ok(page) = &response {
             if page.starts_with("Unknown topic.") {
                 return Err(Error::ProviderError(page.to_owned()));
@@ -47,7 +50,7 @@ mod tests {
 
     #[test]
     fn test_fetch_cheat_sheet() -> Result<()> {
-        let output = CheatDotSh.fetch("ls", &None)?;
+        let output = CheatDotSh.fetch("ls", &None, false)?;
         assert!(output.contains(
             "# To display all files, along with the size (with unit suffixes) and timestamp:"
         ));

--- a/src/helper/docs/cheatsheets.rs
+++ b/src/helper/docs/cheatsheets.rs
@@ -1,4 +1,4 @@
-use crate::helper::docs::HelpProvider;
+use crate::helper::docs::{apply_insecure, HelpProvider};
 use ureq::Agent;
 
 /// The default cheatsheets provider URL.
@@ -17,8 +17,11 @@ impl HelpProvider for Cheatsheets {
         &self,
         cmd: &str,
         url: &str,
+        insecure: bool,
     ) -> ureq::RequestBuilder<ureq::typestate::WithoutBody> {
-        let agent: Agent = Agent::config_builder().build().into();
+        let agent: Agent = apply_insecure(Agent::config_builder(), insecure)
+            .build()
+            .into();
         agent.get(&format!("{}/{}", url, cmd))
     }
 }
@@ -30,7 +33,7 @@ mod tests {
 
     #[test]
     fn test_fetch_cheatsheets() -> Result<()> {
-        let output = Cheatsheets.fetch("ls", &None)?;
+        let output = Cheatsheets.fetch("ls", &None, false)?;
         assert!(output.contains(
             r##"# To display everything in <dir>, including hidden files:
 ls -a <dir>

--- a/src/helper/docs/eg.rs
+++ b/src/helper/docs/eg.rs
@@ -1,4 +1,4 @@
-use crate::helper::docs::HelpProvider;
+use crate::helper::docs::{apply_insecure, HelpProvider};
 use ureq::Agent;
 
 /// EG page provider URL.
@@ -17,8 +17,11 @@ impl HelpProvider for Eg {
         &self,
         cmd: &str,
         url: &str,
+        insecure: bool,
     ) -> ureq::RequestBuilder<ureq::typestate::WithoutBody> {
-        let agent: Agent = Agent::config_builder().build().into();
+        let agent: Agent = apply_insecure(Agent::config_builder(), insecure)
+            .build()
+            .into();
         agent.get(&format!("{}/{}.md", url, cmd))
     }
 }
@@ -30,7 +33,7 @@ mod tests {
 
     #[test]
     fn test_eg_page_fetch() -> Result<()> {
-        let output = Eg.fetch("ls", &None)?;
+        let output = Eg.fetch("ls", &None, false)?;
         assert!(output.contains("show contents of current directory"));
         assert!(output.contains("ls -alh"));
         assert!(output.contains(

--- a/src/helper/docs/mod.rs
+++ b/src/helper/docs/mod.rs
@@ -19,6 +19,26 @@ use dialoguer::theme::ColorfulTheme;
 use dialoguer::Select;
 use std::io::Write;
 use std::process::{Command, Stdio};
+use ureq::config::ConfigBuilder;
+use ureq::tls::TlsConfig;
+use ureq::typestate::AgentScope;
+
+/// Applies the `insecure` setting to an [`Agent`](ureq::Agent) config builder.
+///
+/// When `insecure` is `true`, TLS certificate verification is disabled for the
+/// resulting agent. Otherwise, the builder is returned unchanged and the default
+/// (verification on) behavior is preserved.
+pub(crate) fn apply_insecure(
+    builder: ConfigBuilder<AgentScope>,
+    insecure: bool,
+) -> ConfigBuilder<AgentScope> {
+    if insecure {
+        builder.tls_config(TlsConfig::builder().disable_verification(true).build())
+    } else {
+        builder
+    }
+}
+
 /// The `HelpProvider` trait defines essential methods for fetching help content related to commands from a provider.
 ///
 /// Each provider that implements this trait should provide a default URL used to retrieve the command help content.
@@ -51,6 +71,7 @@ pub trait HelpProvider {
     ///
     /// - `cmd`: The name of the command to be included in the request.
     /// - `url`: The root URL.
+    /// - `insecure`: Whether to disable TLS certificate verification for the request.
     ///
     /// # Returns
     /// This method returns a new `RequestBuilder` configured with the `GET` method and the formatted URL.
@@ -58,6 +79,7 @@ pub trait HelpProvider {
         &self,
         cmd: &str,
         url: &str,
+        insecure: bool,
     ) -> ureq::RequestBuilder<ureq::typestate::WithoutBody>;
 
     /// Handle the request error.
@@ -79,7 +101,7 @@ pub trait HelpProvider {
     /// If a `custom_url` is provided, this URL is used instead of the default URL.
     /// The method will return the content of the command page if the fetch operation is successful.
     #[inline(always)]
-    fn _fetch(&self, cmd: &str, custom_url: &Option<String>) -> Result<String> {
+    fn _fetch(&self, cmd: &str, custom_url: &Option<String>, insecure: bool) -> Result<String> {
         let url = {
             if let Some(u) = custom_url {
                 u.as_str()
@@ -87,7 +109,7 @@ pub trait HelpProvider {
                 self.url()
             }
         };
-        let response = self.build_request(cmd, url).call();
+        let response = self.build_request(cmd, url, insecure).call();
 
         let response = response.map_err(|e| self.handle_error(e));
 
@@ -106,6 +128,7 @@ pub trait HelpProvider {
     ///
     /// - `cmd`: The name of the command for which the page should be fetched.
     /// - `custom_url`: Optional parameter that, if supplied, specifies a custom URL from which to fetch the command page.
+    /// - `insecure`: Whether to disable TLS certificate verification for the request.
     ///
     /// # Returns
     ///
@@ -115,8 +138,8 @@ pub trait HelpProvider {
     /// # Errors
     ///
     /// This method will return an error if the fetch operation fails.
-    fn fetch(&self, cmd: &str, custom_url: &Option<String>) -> Result<String> {
-        self._fetch(cmd, custom_url)
+    fn fetch(&self, cmd: &str, custom_url: &Option<String>, insecure: bool) -> Result<String> {
+        self._fetch(cmd, custom_url, insecure)
     }
 }
 
@@ -144,9 +167,13 @@ pub fn get_docs_help<Output: Write>(cmd: &str, config: &Config, output: &mut Out
             show_man_page(&config.man_command, cmd)?
         } else {
             let page = match selection {
-                Some(CHEAT_SHEET) => CheatDotSh.fetch(cmd, &config.cheat_sh_url)?,
-                Some(EG_PAGE) => Eg.fetch(cmd, &config.eg_url)?,
-                Some(CHEATSHEETS) => Cheatsheets.fetch(cmd, &config.cheatsheets_url)?,
+                Some(CHEAT_SHEET) => {
+                    CheatDotSh.fetch(cmd, &config.cheat_sh_url, config.insecure)?
+                }
+                Some(EG_PAGE) => Eg.fetch(cmd, &config.eg_url, config.insecure)?,
+                Some(CHEATSHEETS) => {
+                    Cheatsheets.fetch(cmd, &config.cheatsheets_url, config.insecure)?
+                }
                 _ => return Ok(()),
             };
             // Show the page using the user selected pager or write it directly into the output
@@ -194,5 +221,22 @@ fn get_selection_theme() -> ColorfulTheme {
         unchecked_item_prefix: style("❤".to_string()).for_stderr().black(),
         picked_item_prefix: style("❯".to_string()).for_stderr().green(),
         unpicked_item_prefix: style(" ".to_string()).for_stderr(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ureq::Agent;
+
+    #[test]
+    fn test_apply_insecure_wires_disable_verification() {
+        let secure: Agent = apply_insecure(Agent::config_builder(), false)
+            .build()
+            .into();
+        assert!(!secure.config().tls_config().disable_verification());
+
+        let insecure: Agent = apply_insecure(Agent::config_builder(), true).build().into();
+        assert!(insecure.config().tls_config().disable_verification());
     }
 }


### PR DESCRIPTION
## Description

Adds an `--insecure` flag to `plz` (and a matching `insecure` config key) that disables TLS certificate verification for the cheat.sh / eg / cheatsheets providers.

An `insecure` parameter is threaded through `HelpProvider::build_request` / `fetch`, and a small `apply_insecure` helper in `helper::docs` applies `TlsConfig::disable_verification` to the agent's `ConfigBuilder` when set. When it isn't set the builder is returned untouched, so the default path is byte-for-byte what it was.

## Motivation and Context

Fixes #210 — behind a TLS-inspecting proxy the providers are served through a certificate that isn't in the system trust store, so every request dies with `invalid peer certificate: UnknownIssuer`.

You mentioned in the issue you weren't sure an ignore option existed. It does now: `ureq` 3.x exposes `TlsConfig::builder().disable_verification(true)`, and the rustls backend honours it by swapping in a `DisabledVerifier` (`ureq-3.3.0/src/tls/rustls.rs:165`) — no extra feature flag needed on top of what `halp` already pulls in.

The issue also floated *"or add your own chain of CAs"*, which is the other half of what you linked (algesten/ureq#386). That's a bigger surface — a path argument, PEM parsing, `RootCerts::Specific` — so I left it out. Happy to follow up with it if you'd prefer that as the primary mechanism and this as the escape hatch.

## How Has This Been Tested?

Unit test `test_apply_insecure_wires_disable_verification` asserts the flag reaches `agent.config().tls_config().disable_verification()` in both directions.

Beyond that I verified it end-to-end against a real self-signed host rather than trusting the wiring — a Python `http.server` on `https://localhost:8443` with an `openssl`-generated self-signed cert, fetched through `CheatDotSh` (temporary test, not part of this diff):

```
insecure=false -> Request error: `io: invalid peer certificate: UnknownIssuer`
insecure=true  -> cheat sheet for ls from a self-signed host
```

The `insecure=false` line is the same error the issue reports, so the flag is demonstrably flipping the behaviour that was broken.

Also ran:
- `cargo test --lib` — 12 passed. 7 fail, but **identically on `upstream/main`** (`helper::args::*` and `helper::tty::*`); they're pty/subprocess tests that don't work in this macOS sandbox, not something this branch touched. My new test is the +1 over the baseline's 11.
- `cargo fmt --check` — clean.
- `cargo clippy --tests --all-features` — 4 warnings, **the same 4 on `upstream/main`** (`src/config.rs:87`/`:88`, `src/error.rs:44`, `src/helper/docs/mod.rs`). Nothing introduced.

Platform: macOS aarch64, Rust stable.

## Screenshots / Logs (if applicable)

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (no code change)
- [ ] Refactor (refactoring production code)
- [ ] Other

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
  - README `plz` options block, a usage example, and the `insecure` key in `config/halp.toml`.
- [x] I have formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

---

One thing I deliberately left alone: the README `plz` options block is already missing `--eg-url` and `--cheat-url` on `main`. I only added my own line rather than widening the diff — say the word if you'd like it regenerated in full here.